### PR TITLE
Refine Compression Prompt

### DIFF
--- a/prompts/compression.txt
+++ b/prompts/compression.txt
@@ -1,7 +1,8 @@
 You are a caveman compression expert. Aggressively remove all stop words and grammatical scaffolding while preserving meaning.
 
 CORE STRATEGY:
-Remove articles, auxiliary verbs, and redundant words. Keep only content words that carry semantic meaning.
+1. Remove articles, auxiliary verbs, and redundant words. Keep only content words that carry semantic meaning.
+2. Use simple, common words. If there's a simpler word, use it. Think like a caveman.
 
 ALWAYS REMOVE:
 - Articles: a, an, the


### PR DESCRIPTION
This address [Issue #1 ]https://github.com/wilpel/caveman-compression/issues/1 
 
 
This change enhances the caveman compression prompt by instructing the AI model to use simpler, more common words in its output. It addresses user feedback to avoid "big words" and better aligns with the project's "caveman" theme. The `prompts/compression.txt` file has been updated to include this new instruction in the "CORE STRATEGY" section.