### PR TITLE
feat: Claude Code plugin for /plugin install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,11 @@
+{
+  "name": "caveman-compression",
+  "owner": { "name": "wilpel" },
+  "description": "Lossless semantic compression for LLM contexts",
+  "plugins": [
+    {
+      "name": "caveman-compression",
+      "source": "./"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "caveman-compression",
+  "description": "Lossless semantic compression for LLM contexts. Strip predictable grammar, keep facts.",
+  "version": "0.1.0",
+  "author": { "name": "wilpel" },
+  "homepage": "https://github.com/wilpel/caveman-compression",
+  "repository": "https://github.com/wilpel/caveman-compression",
+  "license": "MIT"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 *.so
 .Python
 venv/
+.venv/
 env/
 ENV/
 build/

--- a/README.md
+++ b/README.md
@@ -7,9 +7,33 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 
-[Quick Start](#quick-start) • [Examples](#examples) • [Benchmarks](#benchmarks) • [Spec](SPEC.md)
+[Quick Start](#quick-start) • [Claude Code](#claude-code-plugin) • [Examples](#examples) • [Benchmarks](#benchmarks) • [Spec](SPEC.md)
 
 </div>
+
+---
+
+## Claude Code Plugin
+
+Install caveman-compression as a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin in two commands:
+
+```
+/plugin marketplace add wilpel/caveman-compression
+/plugin install caveman-compression@caveman-compression
+```
+
+What you get:
+
+| Command | What |
+|---|---|
+| `/caveman-compress [--engine nlp\|mlm\|llm] [--file PATH \| TEXT]` | Compress text or a file. Auto-bootstraps the venv on first run. |
+| `/caveman-setup [nlp\|mlm\|llm]` | Manually bootstrap the venv for an engine. Idempotent. |
+
+Plus a `caveman-compress` skill that auto-suggests the slash command when you mention compressing prompts, system prompts, or RAG chunks.
+
+Default engine is `nlp` (free, offline, no API key). Switch to `mlm` for predictability-aware compression or `llm` for highest reduction (requires `OPENAI_API_KEY`).
+
+If auto-bootstrap fails, fall back to the manual installation steps in [Quick Start](#quick-start).
 
 ---
 

--- a/bin/caveman-bootstrap.sh
+++ b/bin/caveman-bootstrap.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Bootstrap a virtualenv for caveman-compression engines.
+# Usage: caveman-bootstrap.sh [nlp|mlm|llm]
+#
+# Idempotent: skips work that is already done.
+# Resolves the plugin root from the script's own location so it works whether
+# the plugin is run from a Claude Code plugin install dir or a git clone.
+
+set -euo pipefail
+
+ENGINE="${1:-nlp}"
+case "$ENGINE" in
+    nlp|mlm|llm) ;;
+    *) echo "Unknown engine: $ENGINE (expected nlp|mlm|llm)" >&2; exit 2 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VENV="$PLUGIN_ROOT/.venv"
+REQS="$PLUGIN_ROOT/requirements-${ENGINE}.txt"
+[ "$ENGINE" = "llm" ] && REQS="$PLUGIN_ROOT/requirements.txt"
+
+if [ ! -f "$REQS" ]; then
+    echo "Requirements file not found: $REQS" >&2
+    exit 1
+fi
+
+PYTHON_BIN="${PYTHON:-python3}"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+    echo "python3 not found on PATH. Install Python 3.8+ first." >&2
+    exit 1
+fi
+
+if [ ! -d "$VENV" ]; then
+    echo "Creating venv at $VENV"
+    "$PYTHON_BIN" -m venv "$VENV"
+fi
+
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+
+MARKER="$VENV/.installed-${ENGINE}"
+if [ ! -f "$MARKER" ]; then
+    echo "Installing $ENGINE requirements"
+    pip install --quiet --upgrade pip
+    pip install --quiet -r "$REQS"
+
+    if [ "$ENGINE" = "nlp" ] || [ "$ENGINE" = "mlm" ]; then
+        if ! python -c "import spacy; spacy.load('en_core_web_sm')" >/dev/null 2>&1; then
+            echo "Downloading spaCy en_core_web_sm"
+            python -m spacy download en_core_web_sm
+        fi
+    fi
+
+    touch "$MARKER"
+fi
+
+echo "Bootstrap complete for engine: $ENGINE"
+echo "Activate with: source $VENV/bin/activate"

--- a/commands/caveman-compress.md
+++ b/commands/caveman-compress.md
@@ -1,0 +1,43 @@
+---
+description: Compress text with caveman-compression (default engine nlp)
+argument-hint: "[--engine nlp|mlm|llm] [--file PATH | TEXT]"
+allowed-tools: Bash, Read
+---
+
+Compress the provided text or file using a caveman-compression engine.
+
+Parse `$ARGUMENTS`:
+
+- `--engine nlp|mlm|llm` selects the engine (default `nlp`).
+- `--file PATH` reads input from PATH.
+- Otherwise treat the remaining text as the literal input string.
+
+Steps:
+
+1. If `${CLAUDE_PLUGIN_ROOT}/.venv` does not exist, auto-bootstrap by running:
+
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/bin/caveman-bootstrap.sh" <engine>
+   ```
+
+   If bootstrap fails, stop and print the manual fallback from `/caveman-setup`.
+
+2. Run the engine:
+
+   ```bash
+   source "${CLAUDE_PLUGIN_ROOT}/.venv/bin/activate"
+   case "<engine>" in
+       nlp) python "${CLAUDE_PLUGIN_ROOT}/caveman_compress_nlp.py" compress <args> ;;
+       mlm) python "${CLAUDE_PLUGIN_ROOT}/caveman_compress_mlm.py" compress <args> ;;
+       llm) python "${CLAUDE_PLUGIN_ROOT}/caveman_compress.py"     compress <args> ;;
+   esac
+   ```
+
+   Pass `-f PATH` if `--file` was given; otherwise pass the text positionally (quoted).
+
+3. Print the compressed output verbatim. If the engine printed token counts, surface them.
+
+Notes:
+
+- The `llm` engine needs `OPENAI_API_KEY` in env. If missing, instruct the user to set it.
+- For non-English input with `nlp`, suggest `-l <lang>` (e.g. `-l es`).

--- a/commands/caveman-setup.md
+++ b/commands/caveman-setup.md
@@ -1,0 +1,28 @@
+---
+description: Bootstrap a Python venv for caveman-compression engines (nlp|mlm|llm)
+argument-hint: "[nlp|mlm|llm]"
+allowed-tools: Bash
+---
+
+Bootstrap the caveman-compression engine for engine `$ARGUMENTS` (default `nlp`).
+
+Run the bootstrap script and report the result. The script is idempotent — re-running is safe.
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/bin/caveman-bootstrap.sh" ${ARGUMENTS:-nlp}
+```
+
+If the script fails:
+
+1. Show the user the exact error.
+2. Print the manual fallback:
+
+   ```bash
+   cd "${CLAUDE_PLUGIN_ROOT}"
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements-nlp.txt   # or requirements-mlm.txt / requirements.txt
+   python -m spacy download en_core_web_sm   # for nlp/mlm only
+   ```
+
+After success, tell the user they can now use `/caveman-compress`.

--- a/skills/caveman-compress/SKILL.md
+++ b/skills/caveman-compress/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: caveman-compress
+description: Compress verbose prompts, system prompts, RAG chunks, or any text destined for an LLM into a token-efficient form while preserving facts (numbers, names, technical terms, constraints). Use when (1) the user asks to compress, shrink, or shorten a prompt or document for LLM input, (2) the user complains about token cost or context window pressure on an input prompt, (3) the user pastes a long system prompt and wants it tightened, (4) the user mentions caveman-compression, lossless semantic compression, or wants a free/offline grammar-stripping pass. Do NOT use for compressing the assistant's own output — this skill compresses INPUT text only.
+---
+
+# caveman-compress
+
+This skill wraps the `caveman_compress_nlp.py` and `caveman_compress_mlm.py` scripts shipped with this plugin. It strips predictable grammar (articles, connectives, passive voice, filler) from input text while keeping unpredictable content (numbers, names, dates, technical terms, constraints) intact.
+
+## When to invoke
+
+- User asks: "compress this prompt", "shrink this system prompt", "make this shorter for the LLM", "reduce tokens on this RAG chunk".
+- User pastes a long block and asks for a tightened version to feed to an LLM.
+- User mentions caveman-compression, semantic compression, or token-cost on input.
+
+## When NOT to invoke
+
+- The user wants the *assistant's reply* to be terse — that is the `caveman` skill, not this one.
+- The user wants lossy summarization or paraphrase — this preserves facts only; structure can drop.
+- The user wants binary file compression.
+
+## How to invoke
+
+Use the `/caveman-compress` slash command. Default engine is `nlp` (free, offline, 15-30% reduction). Switch to `mlm` for predictability-aware compression (free, offline, 20-30%) or `llm` for highest reduction (40-58%, requires `OPENAI_API_KEY`).
+
+```
+/caveman-compress --engine nlp --file path/to/prompt.txt
+/caveman-compress --engine mlm "long verbose text here"
+/caveman-compress --engine llm --file system_prompt.md
+```
+
+If the venv is not bootstrapped, the slash command bootstraps it automatically. To bootstrap manually, run `/caveman-setup nlp` (or `mlm` / `llm`).
+
+## Engine choice heuristics
+
+| Need | Engine |
+|------|--------|
+| No API key, fastest install | `nlp` |
+| Better ratio, still offline | `mlm` |
+| Maximum reduction, OK with API call | `llm` |
+| Non-English text | `nlp` with `-l <lang>` |
+
+## Verifying output
+
+After compression, the script reports token counts. Sanity-check that facts (numbers, proper nouns, technical terms) survived. If a critical fact was dropped, switch engines (LLM tends to preserve more) or pre-mark facts in the input.


### PR DESCRIPTION
## Summary

Adds a Claude Code plugin so users can install caveman-compression with two slash commands instead of manual venv + pip steps:

```
/plugin marketplace add wilpel/caveman-compression
/plugin install caveman-compression@caveman-compression
```

The plugin exposes:

- **`/caveman-compress [--engine nlp|mlm|llm] [--file PATH | TEXT]`** — wraps the existing `caveman_compress_nlp.py` / `caveman_compress_mlm.py` / `caveman_compress.py` scripts. Auto-bootstraps the venv on first run; falls back to printing manual install steps if bootstrap fails.
- **`/caveman-setup [nlp|mlm|llm]`** — explicit, idempotent bootstrap per engine.
- **`caveman-compress` skill** — auto-suggests the slash command when the user mentions compressing a prompt / system prompt / RAG chunk. Scope explicitly limited to INPUT compression (not assistant output), so it does not collide with the `caveman` output-compression skill.
- **`bin/caveman-bootstrap.sh`** — creates `.venv`, installs the per-engine requirements, downloads `en_core_web_sm` for nlp/mlm, marks each engine done so re-runs short-circuit.

The marketplace is self-hosted (the repo is its own marketplace, `source: "./"`), so no second repo is needed.

## Files

| Path | Purpose |
|---|---|
| `.claude-plugin/marketplace.json` | Marketplace manifest |
| `.claude-plugin/plugin.json` | Plugin manifest |
| `commands/caveman-compress.md` | Slash command for compression |
| `commands/caveman-setup.md` | Slash command for bootstrap |
| `skills/caveman-compress/SKILL.md` | Auto-trigger skill |
| `bin/caveman-bootstrap.sh` | Idempotent venv installer |
| `README.md` | New "Claude Code Plugin" section |
| `.gitignore` | Adds `.venv/` |

No existing files are touched beyond `README.md` (additive section) and `.gitignore` (one line). The Python sources, requirements files, and CLI behavior are unchanged.

## Test plan

- [ ] `/plugin marketplace add wilpel/caveman-compression` succeeds (schema validates).
- [ ] `/plugin install caveman-compression@caveman-compression` succeeds.
- [ ] `/caveman-setup nlp` creates `.venv`, installs `requirements-nlp.txt`, downloads `en_core_web_sm`.
- [ ] `/caveman-compress "long verbose text"` returns compressed output.
- [ ] `/caveman-compress --engine mlm --file path.txt` works.
- [ ] `/caveman-compress --engine llm "..."` errors cleanly when `OPENAI_API_KEY` unset.
- [ ] Re-running `/caveman-setup nlp` is a no-op.
- [ ] Skill auto-suggests `/caveman-compress` for a "compress this prompt" request.

## Notes for maintainer

- Author / owner fields in the manifests use `wilpel` — happy to change to your preferred display name + email if you want.
- The bootstrap script resolves the plugin root from its own location, so it works whether installed via `/plugin install` or run from a git clone.
- No changes to the existing compression engines — the plugin is a thin wrapper.
